### PR TITLE
Mapp minus sign from digit row; add possibility cancel space.

### DIFF
--- a/src/xhk-layout.h
+++ b/src/xhk-layout.h
@@ -22,6 +22,7 @@
 #define XHK_LAYOUT_H_
 
 enum EN_GB_LAYOUT {
+    KEY_ESC = 9,
     KEY_1 = 10,
     KEY_2,
     KEY_3,
@@ -33,6 +34,7 @@ enum EN_GB_LAYOUT {
     KEY_9,
     KEY_0,
 
+    KEY_MINUS = 20,
     KEY_BACKSPACE = 22,
     KEY_TAB = 23,
 
@@ -62,6 +64,8 @@ enum EN_GB_LAYOUT {
     KEY_SEMICOLON,
     KEY_AT,
     KEY_HASH,
+
+    KEY_GRAVE = 49,
 
     KEY_LSHIFT = 50,
     KEY_BSLASH = 51,

--- a/src/xhk.c
+++ b/src/xhk.c
@@ -271,6 +271,10 @@ int mirror_key(int keycode)
     case KEY_CAPS:
         keycode = KEY_ENTER;
         break;
+
+    case KEY_MINUS:
+        keycode = KEY_GRAVE;
+        break;
     case KEY_GRAVE:
         keycode = KEY_MINUS;
         break;

--- a/src/xhk.c
+++ b/src/xhk.c
@@ -271,6 +271,9 @@ int mirror_key(int keycode)
     case KEY_CAPS:
         keycode = KEY_ENTER;
         break;
+    case KEY_GRAVE:
+        keycode = KEY_MINUS;
+        break;
     }
 
     return keycode;
@@ -349,7 +352,10 @@ int ProcessKeycode(XWindowsScreen_t * screen, int keycode, int up_flag)
         space = SPACE_STATE_MODIFIED; /* Space bar can no longer insert a space char */
         keycode = mirrored_key;
     }
-
+    if(keycode == KEY_ESC && space != SPACE_STATE_START) {
+        space = SPACE_STATE_MODIFIED;
+        return -1;
+    }
     /* Verify that we are only releasing keys that we pressed */
     if (up_flag && keystates[keycode] == KEYSTATE_UP) { /* Perhaps this was the wrong key */
         int mirror = mirror_key(keycode);


### PR DESCRIPTION
I`ve added mirrored mapping for minus sign (it is missed for some reason); also space + esc now discards space character population (looks convenient for me)